### PR TITLE
Add NSLocationWhenInUseUsageDescription

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -44,7 +44,7 @@
              <string>We access your photo library to load or save pictures</string>
          </config-file>
          <config-file target="*-Info.plist" parent="NSLocationWhenInUseUsageDescription">
-             <string></string>
+             <string>We access your location when you take pictures</string>
          </config-file>
     </platform>
     

--- a/plugin.xml
+++ b/plugin.xml
@@ -44,7 +44,7 @@
              <string>We access your photo library to load or save pictures</string>
          </config-file>
          <config-file target="*-Info.plist" parent="NSLocationWhenInUseUsageDescription">
-             <string>We access your location when you take pictures</string>
+             <string>We access your location to improve your experience</string>
          </config-file>
     </platform>
     


### PR DESCRIPTION
**Platform:** iOS
**Issue:** https://outsystemsrd.atlassian.net/browse/RNMT-RNMT-2018
**Description:** Our generate iOS apps don't contain a description for the location.