### PR TITLE
RMNT-2763 Add NSLocationAlwaysUsageDescription tag to Filechooser plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Additions
+- Adds NSLocationAlwaysUsageDescription preference to plugin.xml [RNMT-2763](https://outsystemsrd.atlassian.net/browse/RNMT-2763)
+
+## [1.0.1]
+- Adds Add NSLocationWhenInUseUsageDescription preference to plugin.xml
+
+[Unreleased]: https://github.com/OutSystems/Cordova-Plugin-FileChooser/compare/1.0.1...HEAD
+[1.0.1]: https://github.com/OutSystems/Cordova-Plugin-FileChooser/compare/1.0.0...1.0.1

--- a/plugin.xml
+++ b/plugin.xml
@@ -46,6 +46,9 @@
          <config-file target="*-Info.plist" parent="NSLocationWhenInUseUsageDescription">
              <string>We access your location to improve your experience</string>
          </config-file>
+        <config-file target="*-Info.plist" parent="NSLocationAlwaysUsageDescription">
+            <string>We access your location to improve your experience</string>
+        </config-file>
     </platform>
     
 </plugin>


### PR DESCRIPTION
Mobile application submissions to App Store are being rejected due to `"Missing Purpose String in Info.plist file"` for the `NSLocationAlwaysUsageDescription` key;

This fix adds the preference in plugin.xml and adds the CHANGELOG.md file following our standards.