### PR TITLE
RNMT-3561 File Chooser Plugin ::: Remove NSLocationAlwaysUsageDescription tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removals
+- Remove NSLocationAlwaysUsageDescription preference from plugin.xml [RNMT-3561](https://outsystemsrd.atlassian.net/browse/RNMT-3561)
 
 ## [1.0.2]
 ### Additions

--- a/plugin.xml
+++ b/plugin.xml
@@ -46,9 +46,6 @@
          <config-file target="*-Info.plist" parent="NSLocationWhenInUseUsageDescription">
              <string>We access your location to improve your experience</string>
          </config-file>
-        <config-file target="*-Info.plist" parent="NSLocationAlwaysUsageDescription">
-            <string>We access your location to improve your experience</string>
-        </config-file>
     </platform>
     
 </plugin>


### PR DESCRIPTION
## Description
Removes the NSLocationAlwaysUsageDescription tag from this plugin.

## Context
We added this tag in the context of a previous support case. Now a customer requested us to remove it. After careful evaluation we concluded that this tag is not required in our core. It can be added by supported or third-party plugins that actually require it.

This will only be done in MABS 6 since it is a breaking change (to the service as a whole but not this plugin). Customers using older versions of the Location Plugin without this tag will have to update the plugin when using MABS 6. **We should evaluate adding a new rule to the Validator**.

I also don't know if this should be classified as a fix or feature.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [ ] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Platforms affected
- [ ] Android
- [X] iOS

## Tests
Multiple apps were sent to the store to test this change.

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [X] Pull request title follows the format `RNMT-XXXX <title>`
- [X] Code follows code style of this project
- [X] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
